### PR TITLE
Enhance with try_with_timeout

### DIFF
--- a/src/ConcurrentUtilities.jl
+++ b/src/ConcurrentUtilities.jl
@@ -4,6 +4,7 @@ export Lockable, OrderedSynchronizer, reset!, ReadWriteLock, readlock, readunloc
     Workers, remote_eval, remote_fetch, Worker, terminate!, WorkerTerminatedException,
     Pool, acquire, release, drain!
 
+include("try_with_timeout.jl")
 include("workers.jl")
 using .Workers
 include("lockable.jl")

--- a/src/ConcurrentUtilities.jl
+++ b/src/ConcurrentUtilities.jl
@@ -2,7 +2,7 @@ module ConcurrentUtilities
 
 export Lockable, OrderedSynchronizer, reset!, ReadWriteLock, readlock, readunlock, @wkspawn,
     Workers, remote_eval, remote_fetch, Worker, terminate!, WorkerTerminatedException,
-    Pool, acquire, release, drain!, try_with_timeout
+    Pool, acquire, release, drain!, try_with_timeout, TimeoutError
 
 include("try_with_timeout.jl")
 include("workers.jl")

--- a/src/ConcurrentUtilities.jl
+++ b/src/ConcurrentUtilities.jl
@@ -2,7 +2,7 @@ module ConcurrentUtilities
 
 export Lockable, OrderedSynchronizer, reset!, ReadWriteLock, readlock, readunlock, @wkspawn,
     Workers, remote_eval, remote_fetch, Worker, terminate!, WorkerTerminatedException,
-    Pool, acquire, release, drain!
+    Pool, acquire, release, drain!, try_with_timeout
 
 include("try_with_timeout.jl")
 include("workers.jl")

--- a/src/ConcurrentUtilities.jl
+++ b/src/ConcurrentUtilities.jl
@@ -2,7 +2,7 @@ module ConcurrentUtilities
 
 export Lockable, OrderedSynchronizer, reset!, ReadWriteLock, readlock, readunlock, @wkspawn,
     Workers, remote_eval, remote_fetch, Worker, terminate!, WorkerTerminatedException,
-    Pool, acquire, release, drain!, try_with_timeout, TimeoutError
+    Pool, acquire, release, drain!, try_with_timeout, TimeoutException
 
 include("try_with_timeout.jl")
 include("workers.jl")

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -59,6 +59,14 @@ Stacktrace:
 
 julia> try_with_timeout(_ -> 1, 1, Int)
 1
+
+# usage with `TimedOut`
+julia> try_with_timeout(1) do timedout
+    while !timedout[]
+        # do iterative computation that may take too long
+    end
+end
+
 """
 function try_with_timeout(f, timeout, ::Type{T}=Any) where {T}
     ch = Channel{T}(0)

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -34,7 +34,31 @@ it. If `f` completes successfully, return its result.
 This allows the calling function to check whether the timeout has been reached
 by checking `x[]` and if `true`, the timeout was reached and the function can
 cancel/abort gracefully. The 3rd argument `T` is optional (default `Any`) and
-allows passing an expected return type that `f` should return.
+allows passing an expected return type that `f` should return; this allows avoiding
+a dynamic dispatch from non-inferability of using `try_with_timeout` with `f`.
+
+# Examples
+
+```julia
+julia> try_with_timeout(_ -> 1, 1)
+1
+
+julia> try_with_timeout(_ -> sleep(3), 1)
+ERROR: TimeoutException: try_with_timeout timed out after 1.0 seconds
+Stacktrace:
+ [1] try_with_timeout(::var"#1#2", ::Int64) at ./REPL[1]:1
+ [2] top-level scope at REPL[2]:1
+
+julia> try_with_timeout(_ -> error("hey"), 1)
+ERROR: hey
+Stacktrace:
+ [1] error(::String) at ./error.jl:33
+ [2] (::var"#1#2")(::TimedOut{Any}) at ./REPL[1]:1
+ [3] try_with_timeout(::var"#1#2", ::Int64) at ./REPL[1]:1
+ [4] top-level scope at REPL[3]:1
+
+julia> try_with_timeout(_ -> 1, 1, Int)
+1
 """
 function try_with_timeout(f, timeout, ::Type{T}=Any) where {T}
     ch = Channel{T}(0)

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -1,20 +1,27 @@
+"""
+    TimeoutError
+
+Thrown from `try_with_timeout` when the timeout is reached.
+"""
 struct TimeoutError <: Exception
     timeout::Float64
 end
 
-mutable struct TimedOut{T}
-    ch::Channel{T}
-end
+"""
+    TimedOut
 
-function timeout!(x::TimedOut, timeout)
-    close(x.ch, TimeoutError(timeout))
-    return
+Helper object passed to user-provided `f` in `try_with_timeout`
+that allows checking if the calling context reached a time out.
+Call `x[]`, which returns a `Bool`, to check if the timeout was reached.
+"""
+struct TimedOut{T}
+    ch::Channel{T}
 end
 
 Base.getindex(x::TimedOut) = !isopen(x.ch)
 
 """
-    try_with_timeout(f, timeout, T) -> T
+    try_with_timeout(f, timeout, T=Any) -> T
 
 Run `f` in a new task, and return its result. If `f` does not complete within
 `timeout` seconds, throw a `TimeoutError`. If `f` throws an exception, rethrow
@@ -22,15 +29,16 @@ it. If `f` completes successfully, return its result.
 `f` should be of the form `f(x::TimedOut)`, where `x` is a `TimedOut` object.
 This allows the calling function to check whether the timeout has been reached
 by checking `x[]` and if `true`, the timeout was reached and the function can
-cancel/abort gracefully.
+cancel/abort gracefully. The 3rd argument `T` is optional (default `Any`) and
+allows passing an expected return type that `f` should return.
 """
 function try_with_timeout(f, timeout, ::Type{T}=Any) where {T}
     ch = Channel{T}(0)
     x = TimedOut(ch)
-    timer = Timer(tm -> timeout!(x, timeout), timeout)
+    timer = Timer(tm -> close(ch, TimeoutError(timeout)), timeout)
     Threads.@spawn begin
         try
-            put!(ch, $f(x))
+            put!(ch, $f(x)::T)
         catch e
             close(ch, CapturedException(e, catch_backtrace()))
         finally

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -1,0 +1,41 @@
+struct TimeoutError <: Exception
+    timeout::Float64
+end
+
+mutable struct TimedOut{T}
+    ch::Channel{T}
+end
+
+function timeout!(x::TimedOut, timeout)
+    close(x.ch, TimeoutError(timeout))
+    return
+end
+
+Base.getindex(x::TimedOut) = !isopen(x.ch)
+
+"""
+    try_with_timeout(f, timeout, T) -> T
+
+Run `f` in a new task, and return its result. If `f` does not complete within
+`timeout` seconds, throw a `TimeoutError`. If `f` throws an exception, rethrow
+it. If `f` completes successfully, return its result.
+`f` should be of the form `f(x::TimedOut)`, where `x` is a `TimedOut` object.
+This allows the calling function to check whether the timeout has been reached
+by checking `x[]` and if `true`, the timeout was reached and the function can
+cancel/abort gracefully.
+"""
+function try_with_timeout(f, timeout, ::Type{T}=Any) where {T}
+    ch = Channel{T}(0)
+    x = TimedOut(ch)
+    timer = Timer(tm -> timeout!(x, timeout), timeout)
+    Threads.@spawn begin
+        try
+            put!(ch, $f(x))
+        catch e
+            close(ch, CapturedException(e, catch_backtrace()))
+        finally
+            close(timer)
+        end
+    end
+    return take!(ch)
+end

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -7,8 +7,8 @@ struct TimeoutException <: Exception
     timeout::Float64
 end
 
-function Base.showerror(io::IO, te::TimeoutError)
-    print(io, "TimeoutError: try_with_timeout timed out after $(te.timeout) seconds")
+function Base.showerror(io::IO, te::TimeoutException)
+    print(io, "TimeoutException: try_with_timeout timed out after $(te.timeout) seconds")
 end
 
 """

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -67,6 +67,11 @@ julia> try_with_timeout(1) do timedout
     end
 end
 
+julia> try_with_timeout(1) do timedout
+    sleep(3)
+    timedout[] && abort_gracefully()
+end
+```
 """
 function try_with_timeout(f, timeout, ::Type{T}=Any) where {T}
     ch = Channel{T}(0)

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -7,6 +7,10 @@ struct TimeoutError <: Exception
     timeout::Float64
 end
 
+function Base.showerror(io::IO, te::TimeoutError)
+    print(io, "TimeoutError: try_with_timeout timed out after $(te.timeout) seconds")
+end
+
 """
     TimedOut
 

--- a/src/try_with_timeout.jl
+++ b/src/try_with_timeout.jl
@@ -1,9 +1,9 @@
 """
-    TimeoutError
+    TimeoutException
 
 Thrown from `try_with_timeout` when the timeout is reached.
 """
-struct TimeoutError <: Exception
+struct TimeoutException <: Exception
     timeout::Float64
 end
 
@@ -28,7 +28,7 @@ Base.getindex(x::TimedOut) = !isopen(x.ch)
     try_with_timeout(f, timeout, T=Any) -> T
 
 Run `f` in a new task, and return its result. If `f` does not complete within
-`timeout` seconds, throw a `TimeoutError`. If `f` throws an exception, rethrow
+`timeout` seconds, throw a `TimeoutException`. If `f` throws an exception, rethrow
 it. If `f` completes successfully, return its result.
 `f` should be of the form `f(x::TimedOut)`, where `x` is a `TimedOut` object.
 This allows the calling function to check whether the timeout has been reached
@@ -39,7 +39,7 @@ allows passing an expected return type that `f` should return.
 function try_with_timeout(f, timeout, ::Type{T}=Any) where {T}
     ch = Channel{T}(0)
     x = TimedOut(ch)
-    timer = Timer(tm -> close(ch, TimeoutError(timeout)), timeout)
+    timer = Timer(tm -> close(ch, TimeoutException(timeout)), timeout)
     Threads.@spawn begin
         try
             put!(ch, $f(x)::T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -243,6 +243,7 @@ end # @static if VERSION < v"1.8"
         @test isempty(w.futures)
     end
     include("pools.jl")
+    include("try_with_timeout.jl")
 end
 
     # @testset "@wkspawn" begin

--- a/test/try_with_timeout.jl
+++ b/test/try_with_timeout.jl
@@ -4,7 +4,7 @@ using ConcurrentUtilities, Test
     # test non time out
     @test try_with_timeout(_ -> 1, 1) === 1
     # test time out
-    @test_throws TimeoutError try_with_timeout(1) do timedout
+    @test_throws TimeoutException try_with_timeout(1) do timedout
         sleep(3)
         # this is a weird place to test, but it _does_
         # print a failure if it doesn't work

--- a/test/try_with_timeout.jl
+++ b/test/try_with_timeout.jl
@@ -18,7 +18,7 @@ using ConcurrentUtilities, Test
         rethrow(e.ex)
     end
     # test return type
-    @test @inferred try_with_timeout(_ -> 1, 1, Int) === 1
+    @inferred try_with_timeout(_ -> 1, 1, Int)
     # bad return type
     @test_throws TypeError try
         try_with_timeout(_ -> 1, 1, String)

--- a/test/try_with_timeout.jl
+++ b/test/try_with_timeout.jl
@@ -1,0 +1,29 @@
+using ConcurrentUtilities, Test
+
+@testset "try_with_timeout" begin
+    # test non time out
+    @test try_with_timeout(_ -> 1, 1) === 1
+    # test time out
+    @test_throws TimeoutError try_with_timeout(1) do timedout
+        sleep(3)
+        # this is a weird place to test, but it _does_
+        # print a failure if it doesn't work
+        @test timedout[]
+    end
+    # test exception
+    @test_throws ErrorException try
+        try_with_timeout(_ -> error("hey"), 1)
+    catch e
+        @test e isa CapturedException
+        rethrow(e.ex)
+    end
+    # test return type
+    @test @inferred try_with_timeout(_ -> 1, 1, Int) === 1
+    # bad return type
+    @test_throws TypeError try
+        try_with_timeout(_ -> 1, 1, String)
+    catch e
+        @test e isa CapturedException
+        rethrow(e.ex)
+    end
+end


### PR DESCRIPTION
Actually export `try_with_timeout` since it's so handy and we want to use it in HTTP (and remove it's own copy from there).

Also add a `TimedOut` struct that callers can check to see if their calling context has timed out (and can thus abort their own work more gracefully).

Need to move some of the tests from HTTP, but wanted to get @nickrobinson251 and @Drvi's feedback on this.