### PR TITLE
Add compat entries for stdlibs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,8 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
+Serialization = "1.6"
+Sockets = "1.6"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
The [registry PR](https://github.com/JuliaRegistries/General/pull/94576) failed with:
> The following dependencies do not have a [compat] entry that is upper-bounded and only includes a finite number of breaking releases: Serialization, Sockets

Due to this recent change in requirements: https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958

the advice there is:
> For now you should simply match the version of your Julia compat entry, for all your standard library compat entries.