### PR TITLE
work-a-round bug in Juila <1.9.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConcurrentUtilities"
 uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/src/ConcurrentUtilities.jl
+++ b/src/ConcurrentUtilities.jl
@@ -5,7 +5,7 @@ export Lockable, OrderedSynchronizer, reset!, ReadWriteLock, readlock, readunloc
     Pool, acquire, release, drain!, try_with_timeout, TimeoutException
 
 macro samethreadpool_spawn(expr)
-    if isdefined(Base.Threads, :threadpool)
+    if VERSION >= v"1.9.2"
         esc(:(Threads.@spawn Threads.threadpool() $expr))
     else
         esc(:(Threads.@spawn $expr))


### PR DESCRIPTION
In Julia 1.9.0 and 1.9.1, `Threads.@spawn Threads.threadpool() 1` does not work.  This is a quick+easy work-a-round. see #33.

ref: https://github.com/JuliaLang/julia/pull/50182